### PR TITLE
Add a stage to log function args and return value to timbre

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ sequence of schema sequences.  The first value of each sequence is the
 return type.  A vararg final arg is represented as a single schema
 that should match all varargs.
 
+The `log-scope` stage allows setting of [log-config][log-config]
+logging scopes for `:domain`, `:tags`, and `:context`.
+
+The `log-entry` stage logs function entry at `:trace` using [Timbre][timbre].
+
+The `log-exit` stage logs function exit at `:trace` using [Timbre][timbre].
+
 ## Defining Stages
 
 A stage is a function that takes and a
@@ -50,3 +57,6 @@ Copyright © 2014 Hugo Duncan
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.
+
+[log-config]: https://github.com/palletops/log-config "log-config"
+[timbre]: https://github.com/ptaoussanis/timbre "Timbre"

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.macro "0.1.2"]
-                 [prismatic/schema "0.2.1"]])
+                 [com.palletops/log-config "0.1.2"]
+                 [prismatic/schema "0.2.1"]
+                 [com.taoensso/timbre "3.1.6" :scope "provided"]])

--- a/src/com/palletops/api_builder.clj
+++ b/src/com/palletops/api_builder.clj
@@ -25,7 +25,7 @@
 (def DefnMap
   {:name clojure.lang.Symbol
    :arities [ArityMap]
-   :meta {schema/Keyword schema/Any}})
+   :meta (schema/maybe {schema/Keyword schema/Any})})
 
 (defn arity-map
   [args]

--- a/src/com/palletops/api_builder/stage/log.clj
+++ b/src/com/palletops/api_builder/stage/log.clj
@@ -1,0 +1,81 @@
+(ns com.palletops.api-builder.stage.log
+  "Stages to add logging"
+  (:require
+   [com.palletops.api-builder :refer [DefnMap]]
+   [com.palletops.api-builder.stage :refer [arg-and-ref]]
+   [com.palletops.log-config.timbre
+    :refer [with-context with-domain with-tags]]
+   [schema.core :as schema]
+   [taoensso.timbre :refer [tracef]]))
+
+;;; # Log scope
+(defn add-log-scope
+  [{:keys [args body] :as arity} domain tags context]
+  (assoc arity
+    :body (cond-> body
+                  context (as-> x [`(with-context ~context ~@x)])
+                  domain (as-> x [`(with-domain ~domain ~@x)])
+                  tags (as-> x [`(with-tags ~tags ~@x)]))))
+
+(defn log-scope
+  "A stage that Uses the :domain, :tags and :context keys to configure
+  the logging for the scope of the function.  :domain takes a
+  keyword, :tags takes a set of keywords, :context a map of values."
+  []
+  (fn log-scope [m]
+    {:pre [(schema/validate DefnMap m)]
+     :post [(schema/validate DefnMap %)]}
+    (update-in m [:arities]
+               (fn [ba]
+                 (map
+                  #(add-log-scope
+                    %
+                    (-> m :meta :domain)
+                    (-> m :meta :tags)
+                    (-> m :meta :context))
+                  ba)))))
+
+;;; # Log function entry
+(defn add-entry-logging
+  [fname {:keys [args body] :as arity}]
+  (let [args-and-refs (map arg-and-ref args)]
+    (assoc arity
+      :args (mapv first args-and-refs)
+      :body (concat
+             [`(tracef "%s entry" '~fname
+                       {:args [~@(mapv second args-and-refs)]})]
+             body))))
+
+(defn log-entry
+  "A stage that logs function entry.  The arguments are not shown in
+  the log message, but are available on the message :args key."
+  []
+  (fn log-entry [m]
+    {:pre [(schema/validate DefnMap m)]
+     :post [(schema/validate DefnMap %)]}
+    (update-in m [:arities]
+               (fn [ba]
+                 (map
+                  #(add-entry-logging (:name m) %)
+                  ba)))))
+
+;;; # Log function exit
+(defn add-exit-logging
+  [fname {:keys [args body] :as arity}]
+  (assoc arity
+    :body [`(let [r# (do ~@body)]
+             (tracef "%s exit" '~fname {:return-value r#})
+             r#)]))
+
+(defn log-exit
+  "A stage that logs function exit.  The return value is not shown in
+  the log message, but is available on the message :args key."
+  []
+  (fn log-exit [m]
+    {:pre [(schema/validate DefnMap m)]
+     :post [(schema/validate DefnMap %)]}
+    (update-in m [:arities]
+               (fn [ba]
+                 (map
+                  #(add-exit-logging (:name m) %)
+                  ba)))))

--- a/test/com/palletops/api_builder/stage/log_test.clj
+++ b/test/com/palletops/api_builder/stage/log_test.clj
@@ -1,0 +1,45 @@
+(ns com.palletops.api-builder.stage.log-test
+  (:require
+   [clojure.test :refer :all]
+   [com.palletops.api-builder.stage.log :refer :all]
+   [com.palletops.api-builder :refer [def-defn]]
+   [com.palletops.log-config.timbre :refer [context-msg domain-msg tags-msg]]
+   [taoensso.timbre :refer [log example-config set-level!]]))
+
+(def-defn def-log-scope-fn [(log-scope)])
+(def-defn def-log-entry-fn [(log-entry)])
+(def-defn def-log-exit-fn [(log-exit)])
+
+(defn format-with-domain-context-tags
+  [{:keys [domain context tags]} & _]
+  (str (pr-str domain) (pr-str context) (pr-str tags)))
+
+(def-log-scope-fn scope
+  {:context {:a 1}
+   :domain :d
+   :tags #{:t1 :t2}}
+  []
+  (log (merge example-config
+                 {:fmt-output-fn format-with-domain-context-tags
+                  :middleware [context-msg domain-msg tags-msg]})
+       :info "log %s" 1))
+
+(def-log-entry-fn entry
+  [] 1)
+
+(def-log-exit-fn exit
+  {}
+  [] 1)
+
+(deftest log-scope-test
+  (is (= ":d{:a 1}#{:t1 :t2}\n" (with-out-str (scope)))))
+
+(deftest log-entry-test
+  (set-level! :trace)
+  (is (re-find #"entry entry" (with-out-str (entry)))))
+
+(deftest log-exit-test
+  (set-level! :trace)
+  (is (re-find #"exit exit" (with-out-str (exit))))
+  (with-out-str
+    (is (= 1 (exit)) "doesn't change return value")))


### PR DESCRIPTION
Allow automatic logging of api functions at the :trace level.

Maybe use some :domain metadata to provide a set of tags to filter on.
