### PR TITLE
Add def and defmulti form definers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # api-builder
 
-A Clojure library for writing APIs. API functions are augmented
-versions of standard functions. This augmentation happens at compile
-time and can bring features like validation of parameters based on
-data schemas, logging of parameters, augmentation of docstring based
-on parameter schemas, or even tagging of functions for later grouping
-in documentation.
+A Clojure library for writing APIs. API functions and vars are
+augmented versions of standard functions and vars. This augmentation
+happens at compile time and can bring features like validation of
+parameters based on data schemas, logging of parameters, augmentation
+of docstring based on parameter schemas, or even tagging of functions
+for later grouping in documentation.
 
 To use it, add `[com.palletops/api-builder "0.1.5"]` to your
 `:dependencies`.
@@ -24,16 +24,22 @@ to:
   - ... and even be able group API functions in different groups based
     on domain or other concepts.
 
-This library allows us to do that by building our own `defn` macros
-for API functions with a custom set of stages that each add new
-properties to the functions created.
+This library allows us to do that by building our own `def`, `defn`
+and `defmulti` macros for API functions with a custom set of stages
+that each add new properties to the functions created.
 
 ## Usage
 
-This library provides `def-defn` to create new versions of clojure's
-`defn` forms. These custom `defn` forms augment the created functions with extra
-behavior. This new behavior is defined in a pipeline of _stage_
+This library provides forms to create new versions of clojure's `Var`
+defining forms.
+
+The `def-defn` form creates new versions of clojure's `defn`
+forms. These custom `defn` forms augment the created functions with
+extra behavior. This new behavior is defined in a pipeline of _stage_
 functions, or _stages_.
+
+Similarly, `def-def` creates enhanced versions of clojure's `def`
+forms, and `def-defmulti` enhanced versions of `defmulti` forms.
 
 For example, the provided `defn-api` macro creates functions with with
 error validation, signature validation, addition of signature in

--- a/src/com/palletops/api_builder/api.clj
+++ b/src/com/palletops/api_builder/api.clj
@@ -1,7 +1,7 @@
 (ns com.palletops.api-builder.api
   "An API defn form that uses all stages"
   (:require
-   [com.palletops.api-builder :refer [def-defn]]
+   [com.palletops.api-builder :refer [def-defn def-def def-defmulti]]
    [com.palletops.api-builder.stage :refer :all]
    [com.palletops.api-builder.stage.log :refer :all]))
 
@@ -13,4 +13,17 @@
    (add-sig-doc)
    (log-scope)
    (log-entry)
-   (log-exit)])
+   (log-exit)
+   (add-meta {:api true})])
+
+(def-defmulti defmulti-api
+  [(validate-errors (constantly true))
+   (validate-sig)
+   (add-sig-doc)
+   (log-scope)
+   (log-entry)
+   (log-exit)
+   (add-meta {:api true})])
+
+(def-def def-api
+  [(add-meta {:api true})])

--- a/src/com/palletops/api_builder/stage/log.clj
+++ b/src/com/palletops/api_builder/stage/log.clj
@@ -1,14 +1,15 @@
 (ns com.palletops.api-builder.stage.log
   "Stages to add logging"
   (:require
-   [com.palletops.api-builder.core :refer [arg-and-ref DefnMap]]
+   [com.palletops.api-builder.core
+    :refer [arg-and-ref DefnMap DefFormMap DefMap DefmultiMap DefmethodMap]]
    [com.palletops.log-config.timbre
     :refer [with-context with-domain with-tags]]
    [schema.core :as schema]
    [taoensso.timbre :refer [tracef]]))
 
 ;;; # Log scope
-(defn add-log-scope
+(defn add-log-scope*
   [{:keys [args body] :as arity} domain tags context]
   (assoc arity
     :body (cond-> body
@@ -16,26 +17,59 @@
                   domain (as-> x [`(with-domain ~domain ~@x)])
                   tags (as-> x [`(with-tags ~tags ~@x)]))))
 
+(defn add-log-scope
+  [m meta]
+  (update-in m [:arities]
+             (fn [ba]
+               (map
+                #(add-log-scope*
+                  %
+                  (:domain meta)
+                  (:tags meta)
+                  (:context meta))
+                ba))))
+
+(defmulti log-scope*
+  "A stage that Uses the :domain, :tags and :context keys to configure
+  the logging for the scope of the function.  :domain takes a
+  keyword, :tags takes a set of keywords, :context a map of values."
+  (fn [m] (:type m)))
+
+(defmethod log-scope* :defn
+  [m]
+  {:pre [(schema/validate DefnMap m)]
+   :post [(schema/validate DefnMap %)]}
+  (add-log-scope m (:meta m)))
+
+(defmethod log-scope* :defmulti
+  [m]
+  {:pre [(schema/validate DefmultiMap m)]
+   :post [(schema/validate DefmultiMap %)]}
+  m)
+
+(defmethod log-scope* :defmethod
+  [m]
+  {:pre [(schema/validate DefmethodMap m)]
+   :post [(schema/validate DefmethodMap %)]}
+  (add-log-scope m (-> (resolve (:name m)) meta)))
+
+(defmethod log-scope* :def
+  [m]
+  {:pre [(schema/validate DefMap m)]
+   :post [(schema/validate DefMap %)]}
+  (throw (ex-info
+          "Can not add a log-scope stage to a def form."
+          {:m m})))
+
 (defn log-scope
   "A stage that Uses the :domain, :tags and :context keys to configure
   the logging for the scope of the function.  :domain takes a
   keyword, :tags takes a set of keywords, :context a map of values."
   []
-  (fn log-scope [m]
-    {:pre [(schema/validate DefnMap m)]
-     :post [(schema/validate DefnMap %)]}
-    (update-in m [:arities]
-               (fn [ba]
-                 (map
-                  #(add-log-scope
-                    %
-                    (-> m :meta :domain)
-                    (-> m :meta :tags)
-                    (-> m :meta :context))
-                  ba)))))
+  log-scope*)
 
 ;;; # Log function entry
-(defn add-entry-logging
+(defn add-entry-logging*
   [fname {:keys [args body] :as arity}]
   (let [args-and-refs (map arg-and-ref args)]
     (assoc arity
@@ -45,36 +79,80 @@
                        {:args [~@(mapv second args-and-refs)]})]
              body))))
 
+(defn add-entry-logging
+  [m]
+  (update-in m [:arities]
+             (fn [ba]
+               (map
+                #(add-entry-logging* (:name m) %)
+                ba))))
+
+(defmulti log-entry* (fn [m] (:type m)))
+
+(defmethod log-entry* :defn
+  [m]
+  {:pre [(schema/validate DefnMap m)]
+   :post [(schema/validate DefnMap %)]}
+  (add-entry-logging m))
+
+(defmethod log-entry* :defmulti
+  [m]
+  {:pre [(schema/validate DefmultiMap m)]
+   :post [(schema/validate DefmultiMap %)]}
+  m)
+
+(defmethod log-entry* :defmethod
+  [m]
+  {:pre [(schema/validate DefmethodMap m)]
+   :post [(schema/validate DefmethodMap %)]}
+  (add-entry-logging m))
+
 (defn log-entry
   "A stage that logs function entry.  The arguments are not shown in
   the log message, but are available on the message :args key."
   []
-  (fn log-entry [m]
-    {:pre [(schema/validate DefnMap m)]
-     :post [(schema/validate DefnMap %)]}
-    (update-in m [:arities]
-               (fn [ba]
-                 (map
-                  #(add-entry-logging (:name m) %)
-                  ba)))))
+  log-entry*)
 
 ;;; # Log function exit
-(defn add-exit-logging
+(defn add-exit-logging*
   [fname {:keys [args body] :as arity}]
   (assoc arity
     :body [`(let [r# (do ~@body)]
              (tracef "%s exit" '~fname {:return-value r#})
              r#)]))
+(defn add-exit-logging
+  [m]
+  (update-in m [:arities]
+               (fn [ba]
+                 (map
+                  #(add-exit-logging* (:name m) %)
+                  ba))))
+
+(defmulti log-exit*
+  "A stage that logs function exit.  The return value is not shown in
+  the log message, but is available on the message :args key."
+  (fn [m] (:type m)))
+
+(defmethod log-exit* :defn
+  [m]
+  {:pre [(schema/validate DefnMap m)]
+   :post [(schema/validate DefnMap %)]}
+  (add-exit-logging m))
+
+(defmethod log-exit* :defmulti
+  [m]
+  {:pre [(schema/validate DefmultiMap m)]
+   :post [(schema/validate DefmultiMap %)]}
+  m)
+
+(defmethod log-exit* :defmethod
+  [m]
+  {:pre [(schema/validate DefmethodMap m)]
+   :post [(schema/validate DefmethodMap %)]}
+  (add-exit-logging m))
 
 (defn log-exit
   "A stage that logs function exit.  The return value is not shown in
   the log message, but is available on the message :args key."
   []
-  (fn log-exit [m]
-    {:pre [(schema/validate DefnMap m)]
-     :post [(schema/validate DefnMap %)]}
-    (update-in m [:arities]
-               (fn [ba]
-                 (map
-                  #(add-exit-logging (:name m) %)
-                  ba)))))
+  log-exit*)

--- a/test/com/palletops/api_builder_test.clj
+++ b/test/com/palletops/api_builder_test.clj
@@ -7,13 +7,15 @@
   (is (= {:name 'f-name
           :arities '[{:args [a]
                       :body [a]}]
-          :meta {::x 1}}
+          :meta {::x 1}
+          :type :defn}
          (#'api-builder/defn-map 'f-name [{::x 1} ['a] 'a]))
       "single body")
   (is (= {:name 'f-name
           :arities '[{:args [a] :body [a]}
                      {:args [a b] :body [a b]}]
-          :meta {::x 1}}
+          :meta {::x 1}
+          :type :defn}
          (#'api-builder/defn-map 'f-name [{::x 1} '([a] a) '([a b] a b)]))
       "multi-arity"))
 
@@ -21,19 +23,22 @@
   (is (= {:name nil
           :arities '[{:args [a]
                       :body [a]}]
-          :meta {::x 1}}
+          :meta {::x 1}
+          :type :defn}
          (#'api-builder/fn-map [{::x 1} ['a] 'a]))
       "no name, single body")
   (is (= {:name 'f-name
           :arities '[{:args [a]
                       :body [a]}]
-          :meta {::x 1}}
+          :meta {::x 1}
+          :type :defn}
          (#'api-builder/fn-map ['f-name {::x 1} ['a] 'a]))
       "single body")
   (is (= {:name 'f-name
           :arities '[{:args [a] :body [a]}
                      {:args [a b] :body [a b]}]
-          :meta {::x 1}}
+          :meta {::x 1}
+          :type :defn}
          (#'api-builder/fn-map ['f-name {::x 1} '([a] a) '([a b] a b)]))
       "multi-arity"))
 
@@ -43,7 +48,8 @@
            {:name 'f-name
             :arities '[{:args [a]
                         :body [a]}]
-            :meta {::x 1}}))
+            :meta {::x 1}
+            :type :defn}))
       "single body")
     (is (= '(clojure.core/defn f-name [a] {:pre [a]} a)
          (#'api-builder/defn-form
@@ -51,21 +57,24 @@
             :arities '[{:args [a]
                         :conditions {:pre [a]}
                         :body [a]}]
-            :meta {::x 1}}))
+            :meta {::x 1}
+            :type :defn}))
       "single body with conditions")
     (is (= '(clojure.core/defn f-name ([a] a)([a b] a b))
          (#'api-builder/defn-form
            {:name 'f-name
             :arities '[{:args [a] :body [a]}
                      {:args [a b] :body [a b]}]
-            :meta {::x 1}}))
+            :meta {::x 1}
+            :type :defn}))
         "multi-arity")
     (is (= '(clojure.core/defn f-name ([a] {:pre [a]} a)([a b] a b))
          (#'api-builder/defn-form
            {:name 'f-name
             :arities '[{:args [a] :conditions {:pre [a]} :body [a]}
                      {:args [a b] :body [a b]}]
-            :meta {::x 1}}))
+            :meta {::x 1}
+            :type :defn}))
       "multi-arity with conditions"))
 
 (deftest fn-form-test
@@ -74,14 +83,16 @@
           {:name nil
            :arities '[{:args [a]
                        :body [a]}]
-           :meta {::x 1}}))
+           :meta {::x 1}
+           :type :defn}))
       "no name, single body")
   (is (= '(clojure.core/fn f-name [a] a)
          (#'api-builder/fn-form
           {:name 'f-name
            :arities '[{:args [a]
                        :body [a]}]
-           :meta {::x 1}}))
+           :meta {::x 1}
+           :type :defn}))
       "single body")
   (is (= '(clojure.core/fn f-name [a] {:pre [a]} a)
          (#'api-builder/fn-form
@@ -89,19 +100,22 @@
            :arities '[{:args [a]
                        :conditions {:pre [a]}
                        :body [a]}]
-           :meta {::x 1}}))
+           :meta {::x 1}
+           :type :defn}))
       "single body with conditions")
   (is (= '(clojure.core/fn f-name ([a] a)([a b] a b))
          (#'api-builder/fn-form
           {:name 'f-name
            :arities '[{:args [a] :body [a]}
                       {:args [a b] :body [a b]}]
-           :meta {::x 1}}))
+           :meta {::x 1}
+           :type :defn}))
       "multi-arity")
   (is (= '(clojure.core/fn f-name ([a] {:pre [a]} a)([a b] a b))
          (#'api-builder/fn-form
           {:name 'f-name
            :arities '[{:args [a] :conditions {:pre [a]} :body [a]}
                       {:args [a b] :body [a b]}]
-           :meta {::x 1}}))
+           :meta {::x 1}
+           :type :defn}))
       "multi-arity with conditions"))


### PR DESCRIPTION
Adds `def-def` and `def-defmulti` for defining API vars and multimethods.
